### PR TITLE
스트리밍 페이지 채팅창 Component 구현

### DIFF
--- a/frontend/src/components/Chat/Form.jsx
+++ b/frontend/src/components/Chat/Form.jsx
@@ -1,0 +1,48 @@
+import { Button, TextField } from '@mui/material';
+import React, { useRef } from 'react';
+import styled from 'styled-components';
+
+const StyledForm = styled.form`
+    margin-top: 1rem;
+`;
+
+export default function Form({ handleSubmit }) {
+    const messageInput = useRef();
+
+    const sendMessage = e => {
+        e.preventDefault();
+        handleSubmit(messageInput.current.value);
+    };
+
+    return (
+        <StyledForm onSubmit={sendMessage}>
+            <div>
+                <TextField
+                    fullWidth
+                    label="메시지 입력"
+                    variant="filled"
+                    inputRef={messageInput}
+                />
+            </div>
+            <div style={{ float: 'right', marginTop: '1rem' }}>
+                <Button
+                    style={{ margin: '0 0.5rem' }}
+                    variant="contained"
+                    color="primary"
+                    type="button"
+                >
+                    도네이션
+                </Button>
+                <Button
+                    style={{ margin: '0 0.5rem' }}
+                    variant="contained"
+                    color="primary"
+                    type="button"
+                    onClick={sendMessage}
+                >
+                    채팅
+                </Button>
+            </div>
+        </StyledForm>
+    );
+}

--- a/frontend/src/components/Chat/Message.jsx
+++ b/frontend/src/components/Chat/Message.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const StyledMessage = styled.li`
+    min-height: 30px;
+    margin: 30px;
+`;
+
+export default function Message({ nickname, content }) {
+    return (
+        <StyledMessage>
+            <span>{nickname}</span>: <span>{content}</span>
+        </StyledMessage>
+    );
+}

--- a/frontend/src/components/Chat/MessageList.jsx
+++ b/frontend/src/components/Chat/MessageList.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import { borderBoxMixin } from '@/styles/mixin';
+import Message from './Message';
+
+const StyledMessageList = styled.ul`
+    width: 100%;
+    height: 80%;
+    list-style: none;
+    overflow-y: auto;
+    ::-webkit-scrollbar {
+        width: 8px;
+    }
+    ${({ theme }) => borderBoxMixin('1px', '10px', theme.color.black)}
+    ${({ theme }) => css`
+        ::-webkit-scrollbar-thumb {
+            background-color: ${theme.color.primary};
+            border-radius: 10px;
+        }
+    `}
+`;
+
+export default function MessageList({ messageList }) {
+    function getMessageList() {
+        return messageList.map(message => (
+            <Message nickname={message.nickname} content={message.content} />
+        ));
+    }
+    return <StyledMessageList>{getMessageList()}</StyledMessageList>;
+}

--- a/frontend/src/components/Chat/index.jsx
+++ b/frontend/src/components/Chat/index.jsx
@@ -1,0 +1,38 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { borderBoxMixin } from '@/styles/mixin';
+import Form from './Form';
+import MessageList from './MessageList';
+
+const StyledChat = styled.div`
+    width: 400px;
+    height: 800px;
+    padding: 20px;
+    ${({ theme }) => borderBoxMixin('1px', '0', theme.color.black)};
+`;
+
+export default function Chat() {
+    const [messageList, setMessageList] = useState([]);
+
+    /**
+     * todo: socket 통신으로 messageList set
+     */
+    useEffect(() => {
+        setMessageList([]);
+    }, []);
+
+    /**
+     * todo: message socket 전송
+     * @param {*} message
+     */
+    const handleSubmit = message => {
+        console.log(message);
+    };
+
+    return (
+        <StyledChat>
+            <MessageList messageList={messageList} />
+            <Form handleSubmit={handleSubmit} />
+        </StyledChat>
+    );
+}

--- a/frontend/src/styles/mixin.js
+++ b/frontend/src/styles/mixin.js
@@ -1,0 +1,7 @@
+import { css } from 'styled-components';
+
+const borderBoxMixin = (stroke, radius, color = 'black') => css`
+    border-radius: ${radius};
+    border: ${stroke} solid ${color};
+`;
+export { borderBoxMixin };


### PR DESCRIPTION
## 관련 이슈
- #8 

## 작업 설명
- 스트리밍 페이지에서 채팅창 조회
- 컴포넌트 구조
![image](https://user-images.githubusercontent.com/40783214/139825312-f50cd945-bae2-4c0b-aca3-30789f99082a.png)
![image](https://user-images.githubusercontent.com/40783214/139825350-2e0ebcb3-c554-454e-8983-b4e25e20b113.png)

- mui TexField, Button 사용
- Chat 컴포넌트
   - messageList state 관리 (MessageList의 props 전달)
   - socket 통신 부분 구현 필요
   - handleSubmit() Form의 props 전달(메시지 입력 핸들러)
- mui button priamry 오버라이딩 적용 필요
## 데모 화면(FE 한정)
![image](https://user-images.githubusercontent.com/40783214/139823969-f0e7b6f1-1998-4426-a5c8-235ef0f2f773.png)


## To fix
- `mixin.js` 파일 추가
   -  borderBoxMixin(stroke, radius, color): border radius css mixin (둥근 모서리)