### PR TITLE
카메라 아이콘 클릭시 방송생성 모달 활성화 #5

### DIFF
--- a/frontend/src/components/ChannelDialog/ChannelDialog.stories.js
+++ b/frontend/src/components/ChannelDialog/ChannelDialog.stories.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import ChannelDialog from './index.jsx';
+
+export default {
+    title: 'ChannelDialog',
+    component: ChannelDialog,
+};
+
+const Template = () => <ChannelDialog />;
+
+export const Primary = Template.bind({});
+Primary.args = {};

--- a/frontend/src/components/ChannelDialog/ChannelDialogHook.jsx
+++ b/frontend/src/components/ChannelDialog/ChannelDialogHook.jsx
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+
+export default function ChannelDialogHook() {
+    const [open, setOpen] = useState(false);
+
+    const handleClickOpen = () => {
+        setOpen(true);
+    };
+
+    const handleClose = () => {
+        setOpen(false);
+    };
+
+    return { open, handleClickOpen, handleClose };
+}

--- a/frontend/src/components/ChannelDialog/index.jsx
+++ b/frontend/src/components/ChannelDialog/index.jsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+
+export default function ChannelDialog() {
+    const [open, setOpen] = useState(false);
+
+    const handleClickOpen = () => {
+        setOpen(true);
+    };
+
+    const handleClose = () => {
+        setOpen(false);
+    };
+
+    return (
+        <div>
+            <Button variant="outlined" onClick={handleClickOpen}>
+                Open form dialog
+            </Button>
+            <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
+                <DialogTitle sx={{ textAlign: 'center' }}>Nabaaang</DialogTitle>
+                <DialogContent
+                    sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                    }}
+                >
+                    <TextField
+                        autoFocus
+                        id="title"
+                        label="제목"
+                        type="text"
+                        variant="filled"
+                        margin="normal"
+                        required
+                        style={{ width: '60%' }}
+                    />
+                    <TextField
+                        id="category"
+                        label="카테고리"
+                        type="text"
+                        variant="filled"
+                        margin="normal"
+                        required
+                        style={{ width: '60%' }}
+                    />
+                    <TextField
+                        id="description"
+                        label="설명"
+                        type="text"
+                        variant="filled"
+                        margin="normal"
+                        required
+                        style={{ width: '60%' }}
+                    />
+                </DialogContent>
+                <DialogActions
+                    style={{ display: 'flex', justifyContent: 'center' }}
+                >
+                    <Button onClick={handleClose}>취소</Button>
+                    <Button onClick={handleClose}>방송생성</Button>
+                </DialogActions>
+            </Dialog>
+        </div>
+    );
+}

--- a/frontend/src/components/ChannelDialog/index.jsx
+++ b/frontend/src/components/ChannelDialog/index.jsx
@@ -34,9 +34,11 @@ export default function ChannelDialog() {
                 Open form dialog
             </Button>
             <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
-                <DialogTitle sx={{ textAlign: 'center' }}>Nabaaang</DialogTitle>
+                <DialogTitle style={{ textAlign: 'center' }}>
+                    Nabaaang
+                </DialogTitle>
                 <DialogContent
-                    sx={{
+                    style={{
                         display: 'flex',
                         flexDirection: 'column',
                         alignItems: 'center',

--- a/frontend/src/components/ChannelDialog/index.jsx
+++ b/frontend/src/components/ChannelDialog/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
@@ -7,16 +7,13 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+
+import ChannelDialogHook from './ChannelDialogHook.jsx';
+
 export default function ChannelDialog() {
-    const [open, setOpen] = useState(false);
+    const { open, handleClickOpen, handleClose } = ChannelDialogHook();
 
-    const handleClickOpen = () => {
-        setOpen(true);
-    };
-
-    const handleClose = () => {
-        setOpen(false);
-    };
 
     return (
         <div>

--- a/frontend/src/components/ChannelDialog/index.jsx
+++ b/frontend/src/components/ChannelDialog/index.jsx
@@ -14,6 +14,19 @@ import ChannelDialogHook from './ChannelDialogHook.jsx';
 export default function ChannelDialog() {
     const { open, handleClickOpen, handleClose } = ChannelDialogHook();
 
+    const textFieldTheme = createTheme({
+        components: {
+            MuiTextField: {
+                defaultProps: {
+                    type: 'text',
+                    variant: 'filled',
+                    margin: 'normal',
+                    required: 'true',
+                    style: { width: '60%' },
+                },
+            },
+        },
+    });
 
     return (
         <div>
@@ -29,34 +42,11 @@ export default function ChannelDialog() {
                         alignItems: 'center',
                     }}
                 >
-                    <TextField
-                        autoFocus
-                        id="title"
-                        label="제목"
-                        type="text"
-                        variant="filled"
-                        margin="normal"
-                        required
-                        style={{ width: '60%' }}
-                    />
-                    <TextField
-                        id="category"
-                        label="카테고리"
-                        type="text"
-                        variant="filled"
-                        margin="normal"
-                        required
-                        style={{ width: '60%' }}
-                    />
-                    <TextField
-                        id="description"
-                        label="설명"
-                        type="text"
-                        variant="filled"
-                        margin="normal"
-                        required
-                        style={{ width: '60%' }}
-                    />
+                    <ThemeProvider theme={textFieldTheme}>
+                        <TextField autoFocus id="title" label="제목" />
+                        <TextField id="category" label="카테고리" />
+                        <TextField id="description" label="설명" />
+                    </ThemeProvider>
                 </DialogContent>
                 <DialogActions
                     style={{ display: 'flex', justifyContent: 'center' }}


### PR DESCRIPTION
## 관련 이슈
- #5 

## 작업 설명
메인페이지의 헤더에 카메라 아이콘을 클릭하면 방송 생성 모달이 활성화된다.
현재 PR은 방송 생성 모달만 생성한다.

## 데모화면 (FE 한정)
![image](https://user-images.githubusercontent.com/50704533/139834763-2dc6ecf8-aefd-471d-b558-b99d74400a7c.png)
