### PR TITLE
스트리밍 페이지 영상 레이아웃 구성

### DIFF
--- a/frontend/src/components/Channel/Channel.jsx
+++ b/frontend/src/components/Channel/Channel.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import styled from 'styled-components';
+import { flexMixin } from '@/styles/mixins';
+import tempImage from '@/assets/images/kukucorn.jpg';
+import ChannelCard from '@/components/ChannelCard/ChannelCard';
+import Video from '@/components/Video';
+import Chat from '@/components/Chat';
+
+export default function Channel() {
+    const channelInfo = {
+        id: 1,
+        title: '크으으으롱의 리액트 후우욱스',
+        views: 12000,
+        streamer: {
+            nickname: 'Crong',
+            imageSrc: tempImage,
+        },
+        category: '프로그래밍',
+        isFollow: false,
+        videoSrc:
+            'https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_1MB.mp4',
+    };
+    return (
+        <StyledRow>
+            <StyledColumnLeft>
+                <Video videoSrc={channelInfo.videoSrc} />
+                <ChannelCard />
+            </StyledColumnLeft>
+            <StyledColumnRight>
+                <Chat />
+            </StyledColumnRight>
+        </StyledRow>
+    );
+}
+
+const StyledColumnLeft = styled.div`
+    ${flexMixin('column')}
+    width: 80em;
+    margin: 0 1em;
+`;
+const StyledColumnRight = styled.div`
+    ${flexMixin('column')}
+    margin: 0 1em;
+`;
+
+const StyledRow = styled.div`
+    ${flexMixin('row', 'center')}
+    padding: 1em;
+`;

--- a/frontend/src/components/Channel/Channel.stories.jsx
+++ b/frontend/src/components/Channel/Channel.stories.jsx
@@ -1,0 +1,8 @@
+import Channel from './Channel';
+
+export default {
+    title: 'Channel',
+    component: Channel,
+};
+
+export const Default = Channel.bind();

--- a/frontend/src/components/ChannelCard/Avatar.jsx
+++ b/frontend/src/components/ChannelCard/Avatar.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styled from 'styled-components';
+
+export default function Avatar({ imageSrc }) {
+    return (
+        <AvatarBox>
+            <AvatarImg alt="empty" src={imageSrc} />
+        </AvatarBox>
+    );
+}
+const AvatarBox = styled.div`
+    width: 10em;
+    height: 10em;
+    border-radius: 70%;
+    overflow: hidden;
+`;
+
+const AvatarImg = styled.img`
+    width: 100%;
+    height: 100%;
+`;

--- a/frontend/src/components/ChannelCard/ChannelCard.jsx
+++ b/frontend/src/components/ChannelCard/ChannelCard.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import styled from 'styled-components';
+import { borderBoxMixin } from '@/styles/mixins';
+import tempImage from '@/assets/images/kukucorn.jpg';
+import ChannelDetails from './ChannelDetails';
+
+export default function ChannelCard() {
+    const channelInfo = {
+        id: 1,
+        title: '크으으으롱의 리액트 후우욱스',
+        views: 12000,
+        streamer: {
+            nickname: 'Crong',
+            imageSrc: tempImage,
+        },
+        category: '프로그래밍',
+        isFollow: false,
+    };
+
+    return (
+        <StyledContainer>
+            <ChannelDetails channel={channelInfo} />
+        </StyledContainer>
+    );
+}
+
+const StyledContainer = styled.div`
+    ${({ theme }) => borderBoxMixin('1px', '30px', theme.color.black)};
+    width: 100%;
+    height: 100%;
+`;

--- a/frontend/src/components/ChannelCard/ChannelCard.stories.jsx
+++ b/frontend/src/components/ChannelCard/ChannelCard.stories.jsx
@@ -1,0 +1,8 @@
+import ChannelCard from './ChannelCard';
+
+export default {
+    title: 'ChannelCard',
+    component: ChannelCard,
+};
+
+export const Default = ChannelCard.bind();

--- a/frontend/src/components/ChannelCard/ChannelDetails.jsx
+++ b/frontend/src/components/ChannelCard/ChannelDetails.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import styled from 'styled-components';
+import { borderBoxMixin, flexMixin, fontMixin } from '@/styles/mixins';
+import Button from '../Button';
+import Avatar from './Avatar';
+
+function ChannelDetails({ channel }) {
+    return (
+        <StyledWrapper>
+            <StyledRow>
+                <Avatar imageSrc={channel.streamer.imageSrc} />
+                <StyledColumn>
+                    <StyledName>{channel.streamer.nickname}</StyledName>
+                    <StyledTitle>{channel.title}</StyledTitle>
+                    <StyledHashTag>#{channel.category}</StyledHashTag>
+                </StyledColumn>
+            </StyledRow>
+            <StyledColumn>
+                <Button
+                    color="success"
+                    // onClick={clickHandler}
+                    text="팔로우"
+                    size="medium"
+                />
+                <StyledViews>시청자 수 12000</StyledViews>
+            </StyledColumn>
+        </StyledWrapper>
+    );
+}
+const StyledWrapper = styled.div`
+    ${flexMixin('row', 'space-between')}
+    padding: 1em;
+`;
+
+const StyledRow = styled.div`
+    ${flexMixin('row', 'center')}
+    padding:0.5em;
+`;
+const StyledColumn = styled.div`
+    ${flexMixin('column')}
+    padding:0.5em;
+`;
+const StyledName = styled.div`
+    ${fontMixin('2em', '2em', 'notoSansBold')}
+`;
+
+const StyledTitle = styled.div`
+    ${fontMixin('1em', '1em', 'notoSansMedium')}
+`;
+
+const StyledViews = styled.div`
+    ${fontMixin('1em', '1em', 'notoSansMedium')}
+`;
+
+const StyledHashTag = styled.span`
+    ${({ theme }) => borderBoxMixin('1px', '20px', theme.color.primary)};
+    ${({ theme }) =>
+        fontMixin('1em', '1em', 'notoSansBold', theme.color.white)};
+    background-color: ${({ theme }) => theme.color.primary};
+    text-align: center;
+    width: 6em;
+`;
+export default ChannelDetails;

--- a/frontend/src/components/Chat/Chat.jsx
+++ b/frontend/src/components/Chat/Chat.jsx
@@ -31,8 +31,8 @@ export default function Chat() {
 }
 
 const StyledChat = styled.div`
-    width: 400px;
-    height: 800px;
+    width: 30em;
+    height: 100%;
     padding: 20px;
     ${({ theme }) => borderBoxMixin('1px', '0', theme.color.black)};
 `;

--- a/frontend/src/components/Video/Video.jsx
+++ b/frontend/src/components/Video/Video.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import styled from 'styled-components';
+import { borderBoxMixin } from '@/styles/mixins';
+
+export default function Video({ videoSrc }) {
+    return (
+        <StyledVideo controls autoplay>
+            <source src={videoSrc} />
+        </StyledVideo>
+    );
+}
+
+const StyledVideo = styled.video`
+    ${({ theme }) => borderBoxMixin('1px', '30px', theme.color.black)};
+`;

--- a/frontend/src/components/Video/Video.stories.jsx
+++ b/frontend/src/components/Video/Video.stories.jsx
@@ -1,0 +1,12 @@
+import Video from './Video';
+
+export default {
+    title: 'Video',
+    component: Video,
+};
+
+export const Default = Video.bind();
+Default.args = {
+    videoSrc:
+        'https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_1MB.mp4',
+};

--- a/frontend/src/components/Video/index.jsx
+++ b/frontend/src/components/Video/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './Video';


### PR DESCRIPTION
## 관련 이슈
- #12 
## 작업 설명
#### 구현 Component
- Avatar: 프로필 이미지 렌더링
   - imageSrc
- Video: 비디오 렌더링
   - videoSrc
- ChannelDetails : 방송 정보 렌더링
- ChannelCard : 방송 정보 Wrapper
- Channel : 방송 레이아웃
## 데모 화면(FE 한정)
![image](https://user-images.githubusercontent.com/40783214/140238019-c29af24e-551e-4b54-97a9-962c790aa796.png)
