### PR TITLE
feat: 방송 시청 시  미디어 서버 polling custom hook 구현

### DIFF
--- a/frontend/src/components/Video/Video.jsx
+++ b/frontend/src/components/Video/Video.jsx
@@ -1,38 +1,25 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import styled from 'styled-components';
 import HLS from 'hls.js/dist/hls';
 
 import { sizeMixin } from '@/styles/mixins';
-import { MEDIA_URL } from '@/constants/url';
+import fetchAction from '@/constants/fetchAction';
 
 import Box from '@/components/Common/Box';
+import VideoOverlay from '@/components/VideoOverlay';
+import usePolling from './usePolling';
 
 export default function Video({ streamKey }) {
     const videoRef = useRef();
-    const m3u8URL = `${MEDIA_URL}/${streamKey}.m3u8`;
-
-    const hls = new HLS();
-
-    useEffect(() => {
-        if (HLS.isSupported()) {
-            hls.attachMedia(videoRef.current);
-
-            hls.on(HLS.Events.MEDIA_ATTACHED, () => {
-                hls.loadSource(m3u8URL);
-            });
-
-            hls.on(HLS.Events.ERROR, () => {
-                // hls.loadSource(m3u8URL);
-            });
-
-            hls.on(HLS.Events.MANIFEST_PARSED, () => {
-                videoRef.current.play();
-            });
-        }
-    }, []);
+    const { url, option } = fetchAction({
+        type: 'FETCH_READY_MEDIA',
+        payload: streamKey,
+    });
+    const { loading } = usePolling(url, option, videoRef, 3000);
 
     return HLS.isSupported() ? (
         <Box width="100%" height="100%">
+            {loading && <VideoOverlay open={loading} />}
             <StyledVideo controls autoplay muted ref={videoRef} />
         </Box>
     ) : (

--- a/frontend/src/components/Video/usePolling.jsx
+++ b/frontend/src/components/Video/usePolling.jsx
@@ -1,0 +1,56 @@
+import { useState, useEffect } from 'react';
+import HLS from 'hls.js/dist/hls';
+
+export default function usePolling(url, option, videoRef, delay) {
+    const [error, setError] = useState(false);
+    const [loading, setLoading] = useState(false);
+
+    const fetchPolling = async prevEtag => {
+        setLoading(true);
+        try {
+            const response = await fetch(url, option);
+            if (response.status === 204) {
+                setTimeout(() => {
+                    fetchPolling();
+                }, delay);
+                setLoading(true);
+            } else if (response.status === 200) {
+                const currEtag = response.headers.get('etag');
+                if (prevEtag === currEtag) {
+                    setTimeout(() => {
+                        fetchPolling(currEtag);
+                    }, delay);
+                    return;
+                }
+                if (HLS.isSupported()) {
+                    const hls = new HLS();
+
+                    hls.attachMedia(videoRef.current);
+
+                    hls.on(HLS.Events.MEDIA_ATTACHED, () => {
+                        hls.loadSource(url);
+
+                        hls.on(HLS.Events.MANIFEST_PARSED, () => {
+                            videoRef.current.play();
+                        });
+                        hls.on(HLS.Events.ERROR, async () => {
+                            hls.destroy();
+
+                            const response = await fetch(url, option);
+                            fetchPolling(response.headers.get('etag'));
+                        });
+                    });
+                }
+                setLoading(false);
+            }
+        } catch (err) {
+            setError(true);
+        }
+    };
+
+    useEffect(() => {
+        fetchPolling();
+    }, []);
+
+    return { error, loading };
+}

--- a/frontend/src/constants/fetchAction.js
+++ b/frontend/src/constants/fetchAction.js
@@ -47,6 +47,12 @@ export default function fetchAction({
                             'Content-Type': 'application/json;charset=UTF-8',
                         },
                     },
+        case 'FETCH_READY_MEDIA':
+            return {
+                url: `${MEDIA_URL}/${payload}.m3u8`,
+                option: {
+                    method: 'HEAD',
+                },
             };
         default:
             return '';

--- a/frontend/src/constants/fetchAction.js
+++ b/frontend/src/constants/fetchAction.js
@@ -1,52 +1,48 @@
-import {
-    API_URL
-} from '@/constants/url';
+import { API_URL, MEDIA_URL } from '@/constants/url';
 
-export default function fetchAction({
-    type,
-    payload
-}) {
+export default function fetchAction({ type, payload }) {
     switch (type) {
         case 'FETCH_CREATE_CHANNEL':
             return {
                 url: `${API_URL}/api/channels`,
-                    option: {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json;charset=UTF-8',
-                        },
-                        body: JSON.stringify(payload),
+                option: {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json;charset=UTF-8',
                     },
+                    body: JSON.stringify(payload),
+                },
             };
         case 'FETCH_GET_CHANNEL':
             return {
                 url: `${API_URL}/api/channels/${payload}`,
-                    option: {
-                        method: 'GET',
-                        headers: {
-                            'Content-Type': 'application/json;charset=UTF-8',
-                        },
+                option: {
+                    method: 'GET',
+                    headers: {
+                        'Content-Type': 'application/json;charset=UTF-8',
                     },
+                },
             };
         case 'FETCH_OPEN_CHANNEL':
             return {
                 url: `${API_URL}/api/channels/${payload}/open`,
-                    option: {
-                        method: 'PATCH',
-                        headers: {
-                            'Content-Type': 'application/json;charset=UTF-8',
-                        },
+                option: {
+                    method: 'PATCH',
+                    headers: {
+                        'Content-Type': 'application/json;charset=UTF-8',
                     },
+                },
             };
         case 'FETCH_CLOSE_CHANNEL':
             return {
                 url: `${API_URL}/api/channels/${payload}/close`,
-                    option: {
-                        method: 'PATCH',
-                        headers: {
-                            'Content-Type': 'application/json;charset=UTF-8',
-                        },
+                option: {
+                    method: 'PATCH',
+                    headers: {
+                        'Content-Type': 'application/json;charset=UTF-8',
                     },
+                },
+            };
         case 'FETCH_READY_MEDIA':
             return {
                 url: `${MEDIA_URL}/${payload}.m3u8`,


### PR DESCRIPTION
## 작업 설명
- 방송 시청 시 media server에 m3u8 파일이 생성되지 않았을 경우 polling 해서 비디오 실행
- 방송 시청 중간에 송출이 끊겼을 경우 hls error 이벤트를 통해 미디어 서버 polling
   - 송출이 끊겼지만 m3u8 파일이 media server에 존재하므로 Etag로 resource update 여부를 판단함.
