### PR TITLE
공용 슬라이더 컴포넌트 구현

### DIFF
--- a/frontend/src/components/Common/Slider/Slider/Slider.jsx
+++ b/frontend/src/components/Common/Slider/Slider/Slider.jsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useRef } from 'react';
+import styled, { css } from 'styled-components';
+
+import Box from '@/components/Common/Box';
+import Button from '@/components/Common/Button';
+
+const MOVE_DIR = {
+    prev: -1,
+    next: 1,
+};
+
+export default function Slider({ children, navigation = false }) {
+    const slideContainerRef = useRef(null);
+    const slideCount = useRef(0);
+    const slideIndex = useRef(0);
+
+    const validateMoveSlide = newIndex => {
+        return newIndex >= 0 && newIndex < slideCount.current;
+    };
+
+    const moveSlide = idx => {
+        slideContainerRef.current.style.transform = `translateX(-${
+            idx * 100
+        }%)`;
+    };
+
+    const handleSliceButtonClick = dir => {
+        const newIndex = slideIndex.current + MOVE_DIR[dir];
+        if (validateMoveSlide(newIndex)) {
+            slideIndex.current = newIndex;
+            moveSlide(newIndex);
+        }
+    };
+
+    const showPrevSlide = () => handleSliceButtonClick('prev');
+    const showNextSlide = () => handleSliceButtonClick('next');
+
+    useEffect(() => {
+        if (children) {
+            slideCount.current = children.length;
+        }
+    }, []);
+
+    return (
+        <SliderBox alignItems="stretch">
+            {navigation && (
+                <>
+                    <PrevButtonWrap>
+                        <Button text="prev" onClick={showPrevSlide} />
+                    </PrevButtonWrap>
+
+                    <NextButtonWrap>
+                        <Button text="next" onClick={showNextSlide} />
+                    </NextButtonWrap>
+                </>
+            )}
+
+            <SliderContainer ref={slideContainerRef}>
+                {children}
+            </SliderContainer>
+        </SliderBox>
+    );
+}
+
+const ButtonWrapLayoutCSS = css`
+    position: absolute;
+    height: 100%;
+    z-index: 1;
+`;
+
+const SliderBox = styled(Box)`
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+`;
+
+const SliderContainer = styled(Box)`
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    transition: transform ease-in 500ms;
+    justify-content: unset;
+    align-items: unset;
+`;
+
+const PrevButtonWrap = styled(Box)`
+    ${ButtonWrapLayoutCSS}
+    top: 0;
+    left: 0;
+`;
+
+const NextButtonWrap = styled(Box)`
+    ${ButtonWrapLayoutCSS}
+    top: 0;
+    right: 0;
+`;

--- a/frontend/src/components/Common/Slider/Slider/Slider.stories.jsx
+++ b/frontend/src/components/Common/Slider/Slider/Slider.stories.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import Box from '@/components/Common/Box';
+import Slider from './Slider';
+import SliderItem from '../SliderItem';
+
+const TestComponent = (navigation = false) => (
+    <Box width="300px" height="300px" alignItems="stretch">
+        <Slider navigation={navigation}>
+            <SliderItem>1</SliderItem>
+            <SliderItem>2</SliderItem>
+        </Slider>
+    </Box>
+);
+
+storiesOf('Slider', module)
+    .add('default', () => TestComponent(false))
+    .add('navigation', () => TestComponent(true));

--- a/frontend/src/components/Common/Slider/Slider/index.jsx
+++ b/frontend/src/components/Common/Slider/Slider/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './Slider';

--- a/frontend/src/components/Common/Slider/SliderItem/SlideItem.stories.jsx
+++ b/frontend/src/components/Common/Slider/SliderItem/SlideItem.stories.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import Box from '@/components/Common/Box';
+import SliderItem from './SliderItem';
+
+storiesOf('SliderItem', module)
+    .add('default', () => (
+        <>
+            <SliderItem>1</SliderItem>
+        </>
+    ))
+    .add('mutiple', () => (
+        <Box justifyContent="unset" alignItems="unset">
+            <SliderItem>1</SliderItem>
+            <SliderItem>2</SliderItem>
+        </Box>
+    ));

--- a/frontend/src/components/Common/Slider/SliderItem/SliderItem.jsx
+++ b/frontend/src/components/Common/Slider/SliderItem/SliderItem.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import styled from 'styled-components';
+import Box from '@/components/Common/Box';
+
+export default function SliderItem({ children }) {
+    return <SliderItemBox>{children}</SliderItemBox>;
+}
+
+const SliderItemBox = styled(Box)`
+    width: 100%;
+    flex-shrink: 0;
+`;

--- a/frontend/src/components/Common/Slider/SliderItem/index.jsx
+++ b/frontend/src/components/Common/Slider/SliderItem/index.jsx
@@ -1,0 +1,1 @@
+export { default } from 'SliderItem';

--- a/frontend/src/components/Common/Slider/index.jsx
+++ b/frontend/src/components/Common/Slider/index.jsx
@@ -1,0 +1,4 @@
+import Slider from './Slider';
+import SliderItem from './SliderItem';
+
+export { Slider, SliderItem };

--- a/frontend/src/pages/ChannelManager/ChanerManager.stories.jsx
+++ b/frontend/src/pages/ChannelManager/ChanerManager.stories.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import ChannelManager from '@/components/ChannelManager';
+import ChannelManager from './ChannelManager';
 
 const dummyInfo = {
     title: '바삭끝판왕 BBQ 황금올리브치킨 먹방!🍗',


### PR DESCRIPTION
## 관련 이슈
- #151 

## 작업 설명
- storybook 실행 중 path error가 발생하여 pages/ChannelManager 경로 수정
- OBS 모달을 위해 필요한 슬라이더를 공용 컴포넌트로 작성
- index를 state로 관리하지 않고 모두 useRef로 관리 해 봤습니다.
   - 이유 : CSS로만 애니메이션을 구현하는데 state로 index를 관리하여 렌더링 할 필요가 없다고 판단 
- 이후에 infinite, autoplay, delay와 같은 props 추가 예정
- prev, next 버튼을 화살표 이미지로 수정 예정

## 데모 화면(FE 한정

https://user-images.githubusercontent.com/41893651/142767863-62aadc3d-d6b2-445a-b8bc-1526bcb7c1a8.mp4

