### PR TITLE
메인, 채팅 페이지, 도네이션 모달 레이아웃 변경

### DIFF
--- a/frontend/src/components/Channel/ChannelDetail/ChannelDetail.jsx
+++ b/frontend/src/components/Channel/ChannelDetail/ChannelDetail.jsx
@@ -18,11 +18,10 @@ export default function ChannelDetails({ channelInfo, userCnt }) {
 
             <Box alignItems="flex-start" flexDirection="column">
                 <Typography variant="h5">{nickname}</Typography>
-                <Typography variant="h6">{title}</Typography>
-            </Box>
-
-            <Box alignSelf="flex-start">
-                <Chip text={category} color="success" />
+                <Typography variant="h6" marginBottom={0.5}>
+                    {title}
+                </Typography>
+                <Chip text={`#${category}`} color="success" />
             </Box>
 
             <Box marginLeft="auto" alignSelf="flex-start">

--- a/frontend/src/components/Chat/Chat.jsx
+++ b/frontend/src/components/Chat/Chat.jsx
@@ -30,7 +30,7 @@ export default function Chat() {
             flex={1}
             height="100%"
         >
-            <Box width="100%" flex={5} backgroundColor="white">
+            <Box width="100%" flex={5} backgroundColor="white" marginBottom={1}>
                 <MessageList
                     messageList={messageList}
                     filterUnsentMessage={filterUnsentMessage}

--- a/frontend/src/components/Chat/Chat.jsx
+++ b/frontend/src/components/Chat/Chat.jsx
@@ -30,7 +30,7 @@ export default function Chat() {
             flex={1}
             height="100%"
         >
-            <Box width="100%" flex={3} backgroundColor="white">
+            <Box width="100%" flex={5} backgroundColor="white">
                 <MessageList
                     messageList={messageList}
                     filterUnsentMessage={filterUnsentMessage}

--- a/frontend/src/components/Chat/DonationModal/DonationItem/DonationItem.jsx
+++ b/frontend/src/components/Chat/DonationModal/DonationItem/DonationItem.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
-import { flexMixin, sizeMixin } from '@/styles/mixins';
+import { sizeMixin } from '@/styles/mixins';
+import { Typography, Box } from '@/components/Common';
 
 export default function DonationItem({
     ImageComponent,
@@ -12,24 +13,24 @@ export default function DonationItem({
     };
 
     return (
-        <ItemWrap onClick={handleItemClick}>
+        <BoxWrap
+            onClick={handleItemClick}
+            flexDirection="column"
+            marginRight={1}
+        >
             {ImageComponent}
-            <ItemTitle>{value}</ItemTitle>
-        </ItemWrap>
+            <Typography variant="span">{value}</Typography>
+        </BoxWrap>
     );
 }
 
-const ItemWrap = styled.div`
-    ${flexMixin('column', 'center', 'center')};
+const BoxWrap = styled(Box)`
+    transition: transform ease-in 100ms;
     cursor: pointer;
     &:hover {
         transform: scale(1.1);
     }
     svg {
-        ${sizeMixin('50px', '50px')}
+        ${sizeMixin('40px', '40px')}
     }
-`;
-
-const ItemTitle = styled.h3`
-    font-size: 16px;
 `;

--- a/frontend/src/components/Chat/DonationModal/DonationItemList/DonationItemList.jsx
+++ b/frontend/src/components/Chat/DonationModal/DonationItemList/DonationItemList.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import styled from 'styled-components';
-import { flexMixin } from '@/styles/mixins';
 import { BIT_TYPE } from '@/constants/messageType';
+import { Box } from '@/components/Common';
 import DonationItem from '../DonationItem';
 
 export default function DonationItemList({ handleTotalDonation }) {
     return (
-        <ListWrap>
+        <Box>
             {Object.values(BIT_TYPE).map(({ image, value }) => (
                 <DonationItem
                     key={value}
@@ -15,11 +14,6 @@ export default function DonationItemList({ handleTotalDonation }) {
                     handleTotalDonation={handleTotalDonation}
                 />
             ))}
-        </ListWrap>
+        </Box>
     );
 }
-
-const ListWrap = styled.div`
-    ${flexMixin('row', 'space-between', 'center')};
-    }
-`;

--- a/frontend/src/components/Chat/DonationModal/DonationModal.jsx
+++ b/frontend/src/components/Chat/DonationModal/DonationModal.jsx
@@ -20,22 +20,34 @@ export default function DonationModal({ onDonation }) {
 
     return (
         <Box flexDirection="column">
-            <Typography variant="h3">비트를 선택해주세요</Typography>
+            <Typography variant="h3" marginBottom={2}>
+                비트를 선택해주세요
+            </Typography>
 
-            <Box>
+            <Box marginBottom={2}>
                 <DonationItemList handleTotalDonation={handleTotalDonation} />
             </Box>
 
+            <Box marginBottom={1}>
+                <Typography variant="h5">
+                    총 도네이션 : {totalDonation}
+                </Typography>
+            </Box>
+
             <Box>
-                누적 값 : {totalDonation}
                 <Button
                     onClick={handleTotalDonationInit}
                     text="초기화"
                     color="error"
+                    size="small"
+                    marginRight={1}
+                />
+                <Button
+                    onClick={handleClickSubmit}
+                    text="보내기"
+                    color="success"
                 />
             </Box>
-
-            <Button onClick={handleClickSubmit} text="보내기" color="success" />
         </Box>
     );
 }

--- a/frontend/src/components/Chat/DonationModal/DonationModal.jsx
+++ b/frontend/src/components/Chat/DonationModal/DonationModal.jsx
@@ -15,7 +15,10 @@ export default function DonationModal({ onDonation }) {
     };
 
     const handleClickSubmit = () => {
-        onDonation(totalDonation);
+        if (totalDonation > 0) {
+            handleTotalDonationInit();
+            onDonation(totalDonation);
+        }
     };
 
     return (

--- a/frontend/src/components/Common/Chip/Chip.jsx
+++ b/frontend/src/components/Common/Chip/Chip.jsx
@@ -38,7 +38,6 @@ const StyledChip = styled(Box)`
     border-radius: 15px;
     ${({ color }) => BUTTON_COLOR_TYPE[color]};
     cursor: pointer;
-    margin: 0.5rem;
 `;
 
 const Icon = styled.img`

--- a/frontend/src/components/LiveCollection/LiveDetails.jsx
+++ b/frontend/src/components/LiveCollection/LiveDetails.jsx
@@ -1,21 +1,20 @@
 import React from 'react';
 
-import Avatar from '@/components/Common/Avatar';
-import Box from '@/components/Common/Box';
-import Typography from '@/components/Common/Typography';
+import { Avatar, Box, Typography } from '@/components/Common';
 
-function LiveDetails({ details }) {
+export default function LiveDetails({ details }) {
+    const { streamer, title } = details;
+    const { imageUrl, nickname } = streamer;
+
     return (
         <Box justifyContent="flex-start">
-            <Avatar size="medium" src={details.streamer.imageUrl} />
+            <Box marginRight={1}>
+                <Avatar size="small" src={imageUrl} />
+            </Box>
             <Box flexDirection="column" alignItems="flex-start">
-                <Typography varaint="span">{details.title}</Typography>
-                <Typography varaint="span">
-                    {details.streamer.nickname}
-                </Typography>
+                <Typography varaint="h5">{nickname}</Typography>
+                <Typography varaint="h6">{title}</Typography>
             </Box>
         </Box>
     );
 }
-
-export default LiveDetails;


### PR DESCRIPTION
## 관련 이슈
- #204 

## 작업 설명
- [x] 메인 페이지의 방송 정보 카드에 스트리머 정보, 방송 설명과 아이콘 여백 1rem
- [x] 메인 페이지의 방송 정보, 스트리머 이름 위치 변경
- [x] 채팅 페이지의 카테고리의 위치를 방송 설명 하단에 위치하도록 변경
- [x] 채팅 페이지의 도네이션, 채팅 버튼이 박스 최하단에 위치하도록. 변경
- [x] 도네이션 모달의 리스트 간 간격을 준다.
- [x] 도네이션 모달의 유효성 검사(총 도네이션이 0이면 전송 하지 않는다.)
- [x] 도네이션을 전송 후 총 도네이션은 초기화 된다.

## 데모 화면(FE 한정)
https://user-images.githubusercontent.com/41893651/143400231-ef7e85ef-c941-444e-80a0-cc2ffd163575.mp4



