### PR TITLE
방송 종료 모달이 띄워지고 방송에 나가지지 않는 버그 수정

### DIFF
--- a/frontend/src/components/AlertModal/AlertModal.jsx
+++ b/frontend/src/components/AlertModal/AlertModal.jsx
@@ -1,20 +1,23 @@
-import React, { useContext } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useContext, useEffect } from 'react';
 
 import { ModalContext } from '@/store/ModalStore';
 import { Box, Typography, Button } from '@/components/Common';
 
 function AlertModal() {
-    const { closeModal } = useContext(ModalContext);
+    const { closeModal, setRedirectUrl } = useContext(ModalContext);
 
-    const navigate = useNavigate();
+    useEffect(() => {
+        setRedirectUrl('/');
+    }, []);
+
     const handleSuccessButtonClick = () => {
         closeModal();
-        navigate(`/`);
     };
     return (
         <Box flexDirection="column">
-            <Typography varaint="p" marginBottom={2}>방송이 종료되었습니다.</Typography>
+            <Typography varaint="p" marginBottom={2}>
+                방송이 종료되었습니다.
+            </Typography>
             <Button
                 text="확인"
                 color="success"

--- a/frontend/src/hooks/useModal.js
+++ b/frontend/src/hooks/useModal.js
@@ -1,8 +1,12 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export default () => {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [modalContent, setModalContent] = useState(false);
+    const [redirectUrl, setRedirectUrl] = useState(null);
+
+    const navigate = useNavigate();
 
     const handleModal = (content = false) => {
         setIsModalOpen(!isModalOpen);
@@ -14,6 +18,7 @@ export default () => {
     const closeModal = (content = false) => {
         setIsModalOpen(false);
         setModalContent(content);
+        if (redirectUrl) navigate(redirectUrl);
     };
 
     const openModal = (content = false) => {
@@ -27,6 +32,7 @@ export default () => {
         isModalOpen,
         modalContent,
         handleModal,
+        setRedirectUrl,
         closeModal,
         openModal,
     };

--- a/frontend/src/hooks/useModal.js
+++ b/frontend/src/hooks/useModal.js
@@ -18,7 +18,10 @@ export default () => {
     const closeModal = (content = false) => {
         setIsModalOpen(false);
         setModalContent(content);
-        if (redirectUrl) navigate(redirectUrl);
+        if (redirectUrl) {
+            navigate(redirectUrl);
+            setRedirectUrl(null);
+        }
     };
 
     const openModal = (content = false) => {


### PR DESCRIPTION
## 관련 이슈
- #205 

## 작업 설명
- 방송 종료 모달을 벗어난 부분을 클릭 시, 홈으로 이동
- 방송 종료 모달 X 버튼을 클릭 시, 홈으로 이동

## 데모 화면(FE 한정)
