### PR TITLE
useAuth state reducer로 관리 & Header 컴포넌트 리팩토링

### DIFF
--- a/frontend/src/components/Chat/ChatMessageList/ChatMessageList.jsx
+++ b/frontend/src/components/Chat/ChatMessageList/ChatMessageList.jsx
@@ -9,7 +9,7 @@ export default function ChatMessageList({
     filterUnsentMessage,
     deleteMessage,
 }) {
-    const isScrollBottomRef = useRef(false);
+    const isScrollBottomRef = useRef(true);
     const { scrollRef, isScrollBottom, moveScrollToBottom } = useScroll();
 
     const handleOnScroll = () => {

--- a/frontend/src/components/Chat/hooks/useChatForm.jsx
+++ b/frontend/src/components/Chat/hooks/useChatForm.jsx
@@ -1,0 +1,62 @@
+import React, { useContext } from 'react';
+
+import { v1 } from 'uuid';
+import { ROLE } from '@/constants/role';
+import { UserContext } from '@/store/UserStore';
+import { ModalContext } from '@/store/ModalStore';
+
+import {
+    LoginModalContent,
+    DonationModalContent,
+} from '@/components/ModalContent';
+
+export default function useChatForm({ role, ref, handleSubmit }) {
+    const {
+        userInfo: { user },
+    } = useContext(UserContext);
+    const { openModal } = useContext(ModalContext);
+    const messageInputRef = ref;
+
+    const roleCheck = () => {
+        if (role === ROLE.ALL) return true;
+        openModal(<LoginModalContent />);
+        return false;
+    };
+
+    const createMessage = ({ type, content }) => {
+        return {
+            id: v1(),
+            type,
+            userId: user.id,
+            nickname: user.nickname,
+            content,
+        };
+    };
+
+    const sendTextMessage = e => {
+        e.preventDefault();
+        const content = messageInputRef.current.value;
+        if (content === '') return;
+        if (roleCheck()) {
+            const message = createMessage({ type: 'NORMAL', content });
+            handleSubmit(message);
+            messageInputRef.current.value = '';
+        }
+    };
+
+    const sendDonationMessage = value => {
+        if (roleCheck()) {
+            handleSubmit(createMessage({ type: 'DONATION', content: value }));
+        }
+    };
+
+    const openDonationModal = () => {
+        if (roleCheck()) {
+            openModal(
+                <DonationModalContent onDonation={sendDonationMessage} />,
+            );
+        }
+    };
+
+    return { sendTextMessage, openDonationModal };
+}

--- a/frontend/src/components/Chat/hooks/useChatMessage.js
+++ b/frontend/src/components/Chat/hooks/useChatMessage.js
@@ -1,0 +1,82 @@
+import { useEffect } from 'react';
+
+import { go } from '@/util/fp';
+import socket from '@/socket';
+
+import useBuffer from '@/hooks/useBuffer';
+import useArray from '@/hooks/useArray';
+import useThrottle from '@/hooks/useThrottle';
+
+const THROTTLE_LIMIT = 50;
+const BUFFER_LIMIT = 50;
+const MESSAGE_LIMIT = 150;
+
+export default function useChatMessage() {
+    const { arr: messageList, set: setMessageList } = useArray([]);
+    const { isBufferFull, flushBuffer, getBufferList, pushBuffer } =
+        useBuffer(BUFFER_LIMIT);
+
+    const concatBufferToMessage = msg => msg.concat(getBufferList());
+    const sliceMessage = msg => msg.slice(-MESSAGE_LIMIT);
+
+    const handleMessageSetState = prevMsg => {
+        return go(prevMsg, concatBufferToMessage, sliceMessage);
+    };
+
+    const updateMessage = () => {
+        setMessageList(handleMessageSetState);
+        flushBuffer();
+    };
+
+    const onThrottle = useThrottle(updateMessage, THROTTLE_LIMIT, isBufferFull);
+
+    const throttleNewMessage = msg => {
+        pushBuffer(msg);
+        onThrottle();
+    };
+
+    const getMessageIdxToRemove = unsentMessageList => {
+        const toRemove = [];
+        unsentMessageList.forEach(unsent => {
+            const idxToRemove = messageList.findIndex(
+                message => message.id === unsent.id && message.status,
+            );
+            toRemove.push(idxToRemove);
+        });
+        return toRemove;
+    };
+
+    const removeUnsentFromMessageList = toRemove => {
+        return messageList.filter((_, idx) => !toRemove.includes(idx));
+    };
+
+    const filterUnsentMessage = () => {
+        const unsentMessageList = messageList.filter(x => x.status === false);
+        if (unsentMessageList.length) {
+            return go(
+                unsentMessageList,
+                getMessageIdxToRemove,
+                removeUnsentFromMessageList,
+            );
+        }
+        return messageList;
+    };
+
+    const deleteMessage = id => () => {
+        setMessageList(prev => prev.filter(x => x.id !== id));
+    };
+
+    useEffect(() => {
+        socket.chat.onMessage(throttleNewMessage);
+        return () => {
+            socket.chat.clearChatEvents();
+        };
+    }, []);
+
+    return {
+        messageList,
+        filterUnsentMessage,
+        deleteMessage,
+        throttleNewMessage,
+    };
+}

--- a/frontend/src/components/Header/Header.jsx
+++ b/frontend/src/components/Header/Header.jsx
@@ -7,6 +7,8 @@ import { ReactComponent as CameraIcon } from '@/assets/images/camera-icon.svg';
 import { flexMixin } from '@/styles/mixins';
 import ProfileIcon from '@/assets/images/profile-icon.svg';
 import STATUS from '@/constants/statusCode';
+import { removeItemFromLocalStorage } from '@/util';
+import { AUTH_TOKEN_LIST } from '@/constants/auth';
 
 import { UserContext } from '@/store/UserStore';
 import { ModalContext } from '@/store/ModalStore';
@@ -22,22 +24,20 @@ import {
 
 export default function Header() {
     const { handleModal, openModal } = useContext(ModalContext);
-    const { setUserInfo, userInfo, authSignOut } = useContext(UserContext);
+    const { userInfo, dispatch } = useContext(UserContext);
 
     const navigate = useNavigate();
 
     const changeNicknameHandler = () => {
-        handleModal(
-            <NicknameModalContent
-                onSubmit={handleOnChangeNickname}
-                setUserInfo={setUserInfo}
-                userInfo={userInfo}
-            />,
-        );
+        handleModal(<NicknameModalContent 
+            userInfo={userInfo}
+            dispatch={dispatch}
+            onSubmit={handleOnChangeNickname} />);
     };
 
     const logoutHandler = () => {
-        authSignOut();
+        removeItemFromLocalStorage(AUTH_TOKEN_LIST);
+        dispatch({ type: 'SIGN_OUT' });
         navigate(window.location.pathname);
     };
 

--- a/frontend/src/components/Header/Header.jsx
+++ b/frontend/src/components/Header/Header.jsx
@@ -1,131 +1,26 @@
 import React, { useContext } from 'react';
 import styled from 'styled-components';
 
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import HeaderLogo from '@/assets/images/header-logo.svg';
-import { ReactComponent as CameraIcon } from '@/assets/images/camera-icon.svg';
 import { flexMixin } from '@/styles/mixins';
-import ProfileIcon from '@/assets/images/profile-icon.svg';
-import STATUS from '@/constants/statusCode';
-import { removeItemFromLocalStorage } from '@/util';
-import { AUTH_TOKEN_LIST } from '@/constants/auth';
 
 import { UserContext } from '@/store/UserStore';
-import { ModalContext } from '@/store/ModalStore';
-import { Button, Box, IconButton, DropDown } from '@/components/Common';
-import { fetchCreateChannel, fetchChannelOwnedByUser } from '@/apis/channel';
-import { fetchUpdateNickname } from '@/apis/user';
-import {
-    NicknameModalContent,
-    ChannelDetailModalContent,
-    LoginModalContent,
-    ChannelModalContent,
-} from '@/components/ModalContent';
+
+import SignInMenu from './SignInMenu';
+import SignOutMenu from './SignOutMenu';
 
 export default function Header() {
-    const { handleModal, openModal } = useContext(ModalContext);
-    const { userInfo, dispatch } = useContext(UserContext);
-
-    const navigate = useNavigate();
-
-    const changeNicknameHandler = () => {
-        handleModal(<NicknameModalContent 
-            userInfo={userInfo}
-            dispatch={dispatch}
-            onSubmit={handleOnChangeNickname} />);
-    };
-
-    const logoutHandler = () => {
-        removeItemFromLocalStorage(AUTH_TOKEN_LIST);
-        dispatch({ type: 'SIGN_OUT' });
-        navigate(window.location.pathname);
-    };
-
-    const handleOnClickCameraIcon = async () => {
-        const { user } = userInfo;
-        const { data: channelInfo, status } = await fetchChannelOwnedByUser(
-            user.id,
-        );
-
-        if (status === STATUS.NO_CONTENT) {
-            openModal(
-                <ChannelModalContent
-                    subHandleOnSubmit={handleOnCreateChannel}
-                    successText="방송 시작"
-                />,
-            );
-        } else if (status === STATUS.OK) {
-            openModal(<ChannelDetailModalContent channelInfo={channelInfo} />);
-        }
-    };
-
-    const handleOnCreateChannel = async formData => {
-        try {
-            const channelID = await fetchCreateChannel(formData);
-            navigate(`/stream-manager/${channelID}`);
-        } catch (err) {
-            throw new Error(err);
-        }
-    };
-
-    const handleOnChangeNickname = async data => {
-        try {
-            const response = await fetchUpdateNickname({
-                ...data,
-                id: userInfo.user.id,
-            });
-            return response;
-        } catch (err) {
-            throw new Error(err);
-        }
-    };
-
-    const profileDropDownItems = () => {
-        const items = [
-            ['닉네임 변경', changeNicknameHandler],
-            ['로그아웃', logoutHandler],
-        ];
-
-        const dropDownItems = items.map(([text, handler]) => {
-            return { text, handler };
-        });
-
-        return dropDownItems;
-    };
+    const {
+        userInfo: { isSignIn },
+    } = useContext(UserContext);
 
     return (
         <HeaderWrap>
             <Link to="/">
-                <Logo src={HeaderLogo} alt="header-logo" />
+                <Logo src={HeaderLogo} alt="header_logo" />
             </Link>
-
-            {!userInfo.isSignIn ? (
-                <Button
-                    text="로그인"
-                    size="medium"
-                    onClick={() => handleModal(<LoginModalContent />)}
-                />
-            ) : (
-                <Box>
-                    <IconButton
-                        size="large"
-                        type="square"
-                        onClick={handleOnClickCameraIcon}
-                    >
-                        <CameraIcon />
-                    </IconButton>
-
-                    <DropDown
-                        toggleButtonChild={
-                            <IconButton type="square" size="large">
-                                <Logo src={ProfileIcon} />
-                            </IconButton>
-                        }
-                        items={profileDropDownItems()}
-                        contentPos={{ top: '4rem', right: '0' }}
-                    />
-                </Box>
-            )}
+            {!isSignIn ? <SignInMenu /> : <SignOutMenu />}
         </HeaderWrap>
     );
 }

--- a/frontend/src/components/Header/SignInMenu/SignInMenu.jsx
+++ b/frontend/src/components/Header/SignInMenu/SignInMenu.jsx
@@ -1,0 +1,16 @@
+import React, { useContext } from 'react';
+import { Button } from '@/components/Common';
+import { ModalContext } from '@/store/ModalStore';
+
+import { LoginModalContent } from '@/components/ModalContent';
+
+export default function SignInMenu() {
+    const { openModal } = useContext(ModalContext);
+    return (
+        <Button
+            text="로그인"
+            size="medium"
+            onClick={() => openModal(<LoginModalContent />)}
+        />
+    );
+}

--- a/frontend/src/components/Header/SignInMenu/index.jsx
+++ b/frontend/src/components/Header/SignInMenu/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './SignInMenu';

--- a/frontend/src/components/Header/SignOutMenu/SignOutMenu.jsx
+++ b/frontend/src/components/Header/SignOutMenu/SignOutMenu.jsx
@@ -1,0 +1,117 @@
+import React, { useContext } from 'react';
+
+import { useNavigate } from 'react-router-dom';
+
+import STATUS from '@/constants/statusCode';
+import { UserContext } from '@/store/UserStore';
+import { ModalContext } from '@/store/ModalStore';
+import { removeItemFromLocalStorage } from '@/util';
+import { AUTH_TOKEN_LIST } from '@/constants/auth';
+import { ReactComponent as CameraIcon } from '@/assets/images/camera-icon.svg';
+import { ReactComponent as ProfileIcon } from '@/assets/images/profile-icon.svg';
+
+import { fetchCreateChannel, fetchChannelOwnedByUser } from '@/apis/channel';
+import { fetchUpdateNickname } from '@/apis/user';
+import { Box, IconButton, DropDown } from '@/components/Common';
+import {
+    NicknameModalContent,
+    ChannelDetailModalContent,
+    ChannelModalContent,
+} from '@/components/ModalContent';
+
+export default function SignOutMenu() {
+    const { userInfo, dispatch } = useContext(UserContext);
+    const { openModal, handleModal } = useContext(ModalContext);
+    const { user } = userInfo;
+
+    const navigate = useNavigate();
+
+    const handleOnCreateChannel = async formData => {
+        try {
+            const channelID = await fetchCreateChannel(formData);
+            navigate(`/stream-manager/${channelID}`);
+        } catch (err) {
+            throw new Error(err);
+        }
+    };
+
+    const handleOnClickCameraIcon = async () => {
+        const { data: channelInfo, status } = await fetchChannelOwnedByUser(
+            user.id,
+        );
+
+        if (status === STATUS.NO_CONTENT) {
+            openModal(
+                <ChannelModalContent
+                    subHandleOnSubmit={handleOnCreateChannel}
+                    successText="방송 시작"
+                />,
+            );
+        } else if (status === STATUS.OK) {
+            openModal(<ChannelDetailModalContent channelInfo={channelInfo} />);
+        }
+    };
+
+    const handleOnChangeNickname = async data => {
+        try {
+            const response = await fetchUpdateNickname({
+                ...data,
+                id: userInfo.user.id,
+            });
+            return response;
+        } catch (err) {
+            throw new Error(err);
+        }
+    };
+
+    const changeNicknameHandler = () => {
+        handleModal(
+            <NicknameModalContent
+                userInfo={userInfo}
+                dispatch={dispatch}
+                onSubmit={handleOnChangeNickname}
+            />,
+        );
+    };
+
+    const logoutHandler = () => {
+        removeItemFromLocalStorage(AUTH_TOKEN_LIST);
+        dispatch({ type: 'SIGN_OUT' });
+        navigate(window.location.pathname);
+    };
+
+    const profileDropDownItems = () => {
+        const items = [
+            ['닉네임 변경', changeNicknameHandler],
+            ['로그아웃', logoutHandler],
+        ];
+
+        const dropDownItems = items.map(([text, handler]) => {
+            return { text, handler };
+        });
+
+        return dropDownItems;
+    };
+
+    return (
+        <Box>
+            <IconButton
+                size="large"
+                type="square"
+                onClick={handleOnClickCameraIcon}
+            >
+                <CameraIcon />
+            </IconButton>
+
+            <DropDown
+                toggleButtonChild={
+                    <IconButton type="square" size="large">
+                        <ProfileIcon />
+                    </IconButton>
+                }
+                items={profileDropDownItems()}
+                contentPos={{ top: '4rem', right: '0' }}
+            />
+        </Box>
+    );
+}

--- a/frontend/src/components/Header/SignOutMenu/SignOutMenu.jsx
+++ b/frontend/src/components/Header/SignOutMenu/SignOutMenu.jsx
@@ -1,89 +1,17 @@
-import React, { useContext } from 'react';
-
-import { useNavigate } from 'react-router-dom';
-
-import STATUS from '@/constants/statusCode';
-import { UserContext } from '@/store/UserStore';
-import { ModalContext } from '@/store/ModalStore';
-import { removeItemFromLocalStorage } from '@/util';
-import { AUTH_TOKEN_LIST } from '@/constants/auth';
+import React from 'react';
 import { ReactComponent as CameraIcon } from '@/assets/images/camera-icon.svg';
 import { ReactComponent as ProfileIcon } from '@/assets/images/profile-icon.svg';
-
-import { fetchCreateChannel, fetchChannelOwnedByUser } from '@/apis/channel';
-import { fetchUpdateNickname } from '@/apis/user';
 import { Box, IconButton, DropDown } from '@/components/Common';
-import {
-    NicknameModalContent,
-    ChannelDetailModalContent,
-    ChannelModalContent,
-} from '@/components/ModalContent';
+import useSignOutMenu from '../hooks/useSignOutMenu';
 
 export default function SignOutMenu() {
-    const { userInfo, dispatch } = useContext(UserContext);
-    const { openModal, handleModal } = useContext(ModalContext);
-    const { user } = userInfo;
-
-    const navigate = useNavigate();
-
-    const handleOnCreateChannel = async formData => {
-        try {
-            const channelID = await fetchCreateChannel(formData);
-            navigate(`/stream-manager/${channelID}`);
-        } catch (err) {
-            throw new Error(err);
-        }
-    };
-
-    const handleOnClickCameraIcon = async () => {
-        const { data: channelInfo, status } = await fetchChannelOwnedByUser(
-            user.id,
-        );
-
-        if (status === STATUS.NO_CONTENT) {
-            openModal(
-                <ChannelModalContent
-                    subHandleOnSubmit={handleOnCreateChannel}
-                    successText="방송 시작"
-                />,
-            );
-        } else if (status === STATUS.OK) {
-            openModal(<ChannelDetailModalContent channelInfo={channelInfo} />);
-        }
-    };
-
-    const handleOnChangeNickname = async data => {
-        try {
-            const response = await fetchUpdateNickname({
-                ...data,
-                id: userInfo.user.id,
-            });
-            return response;
-        } catch (err) {
-            throw new Error(err);
-        }
-    };
-
-    const changeNicknameHandler = () => {
-        handleModal(
-            <NicknameModalContent
-                userInfo={userInfo}
-                dispatch={dispatch}
-                onSubmit={handleOnChangeNickname}
-            />,
-        );
-    };
-
-    const logoutHandler = () => {
-        removeItemFromLocalStorage(AUTH_TOKEN_LIST);
-        dispatch({ type: 'SIGN_OUT' });
-        navigate(window.location.pathname);
-    };
+    const { openChannelModal, openNicknameModal, signOutHandler } =
+        useSignOutMenu();
 
     const profileDropDownItems = () => {
         const items = [
-            ['닉네임 변경', changeNicknameHandler],
-            ['로그아웃', logoutHandler],
+            ['닉네임 변경', openNicknameModal],
+            ['로그아웃', signOutHandler],
         ];
 
         const dropDownItems = items.map(([text, handler]) => {
@@ -95,11 +23,7 @@ export default function SignOutMenu() {
 
     return (
         <Box>
-            <IconButton
-                size="large"
-                type="square"
-                onClick={handleOnClickCameraIcon}
-            >
+            <IconButton size="large" type="square" onClick={openChannelModal}>
                 <CameraIcon />
             </IconButton>
 

--- a/frontend/src/components/Header/SignOutMenu/index.jsx
+++ b/frontend/src/components/Header/SignOutMenu/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './SignOutMenu';

--- a/frontend/src/components/Header/hooks/useSignOutMenu.js
+++ b/frontend/src/components/Header/hooks/useSignOutMenu.js
@@ -1,0 +1,84 @@
+import React, { useContext } from 'react';
+
+import { useNavigate } from 'react-router-dom';
+
+import STATUS from '@/constants/statusCode';
+import { UserContext } from '@/store/UserStore';
+import { ModalContext } from '@/store/ModalStore';
+import { removeItemFromLocalStorage } from '@/util';
+import { AUTH_TOKEN_LIST } from '@/constants/auth';
+import { fetchCreateChannel, fetchChannelOwnedByUser } from '@/apis/channel';
+import { fetchUpdateNickname } from '@/apis/user';
+import {
+    NicknameModalContent,
+    ChannelDetailModalContent,
+    ChannelModalContent,
+} from '@/components/ModalContent';
+
+export default function useSignOutMenu() {
+    const { userInfo, dispatch } = useContext(UserContext);
+    const { openModal } = useContext(ModalContext);
+    const { user } = userInfo;
+
+    const navigate = useNavigate();
+
+    const createChannel = async formData => {
+        try {
+            const channelID = await fetchCreateChannel(formData);
+            navigate(`/stream-manager/${channelID}`);
+        } catch (err) {
+            throw new Error(err);
+        }
+    };
+
+    const openChannelModal = async () => {
+        const { data: channelInfo, status } = await fetchChannelOwnedByUser(
+            user.id,
+        );
+
+        if (status === STATUS.NO_CONTENT) {
+            openModal(
+                <ChannelModalContent
+                    subHandleOnSubmit={createChannel}
+                    successText="방송 시작"
+                />,
+            );
+        } else if (status === STATUS.OK) {
+            openModal(<ChannelDetailModalContent channelInfo={channelInfo} />);
+        }
+    };
+
+    const changeNickname = async data => {
+        try {
+            const response = await fetchUpdateNickname({
+                ...data,
+                id: userInfo.user.id,
+            });
+            return response;
+        } catch (err) {
+            throw new Error(err);
+        }
+    };
+
+    const openNicknameModal = () => {
+        openModal(
+            <NicknameModalContent
+                userInfo={userInfo}
+                dispatch={dispatch}
+                onSubmit={changeNickname}
+            />,
+        );
+    };
+
+    const signOutHandler = () => {
+        removeItemFromLocalStorage(AUTH_TOKEN_LIST);
+        dispatch({ type: 'SIGN_OUT' });
+        navigate(window.location.pathname);
+    };
+
+    return {
+        openChannelModal,
+        openNicknameModal,
+        signOutHandler,
+    };
+}

--- a/frontend/src/components/ModalContent/Nickname/Nickname.jsx
+++ b/frontend/src/components/ModalContent/Nickname/Nickname.jsx
@@ -5,13 +5,12 @@ import { ModalContext } from '@/store/ModalStore';
 
 import { Box, Button, Typography } from '@/components/Common';
 
-export default function Nickname({ onSubmit, setUserInfo, userInfo }) {
+export default function Nickname({ onSubmit, userInfo, dispatch }) {
     const { closeModal } = useContext(ModalContext);
+    const { user } = userInfo;
 
     const inputRef = useRef();
     const [error, setError] = useState(null);
-
-    const { isSignIn, user } = userInfo;
 
     const handleOnSubmit = async () => {
         try {
@@ -20,7 +19,10 @@ export default function Nickname({ onSubmit, setUserInfo, userInfo }) {
             else {
                 await onSubmit({ nickname: inputData });
                 const updatedUser = { ...user, nickname: inputData };
-                setUserInfo({ isSignIn, user: updatedUser });
+                dispatch({
+                    type: 'CHANGE_NICKNAME',
+                    payload: { user: updatedUser },
+                });
                 closeModal();
             }
         } catch (err) {

--- a/frontend/src/components/OauthCallback/GoogleAuthCallback.jsx
+++ b/frontend/src/components/OauthCallback/GoogleAuthCallback.jsx
@@ -2,12 +2,14 @@ import React, { useContext, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import qs from 'qs';
 
+import { setItemToLocalStorage } from '@/util';
+
 import { fetchSiginInGoogle } from '@/apis/auth';
 import { UserContext } from '@/store/UserStore';
 import { Loading } from '@/components/Common';
 
 export default function GoogleAuthCallback() {
-    const { authSignIn } = useContext(UserContext);
+    const { dispatch } = useContext(UserContext);
     const { search } = useLocation();
     const navigate = useNavigate();
     const { code, state } = qs.parse(search, {
@@ -18,12 +20,14 @@ export default function GoogleAuthCallback() {
     const handleSignIn = async () => {
         try {
             const res = await fetchSiginInGoogle(code);
-            authSignIn({
-                type: 'success',
-                payload: { ...res, isSignIn: true },
+            const { user, accessToken, refreshToken } = res;
+            setItemToLocalStorage({ accessToken, refreshToken });
+            dispatch({
+                type: 'SIGN_IN_SUCCESS',
+                payload: { user },
             });
         } catch (err) {
-            authSignIn({ type: 'error' });
+            dispatch({ type: 'SIGN_IN_ERROR' });
         } finally {
             navigate(referrer);
         }

--- a/frontend/src/reducer/userAuthReducer.js
+++ b/frontend/src/reducer/userAuthReducer.js
@@ -1,0 +1,13 @@
+export default function userAuthReducer(userInfo, { type, payload }) {
+    switch (type) {
+        case 'SIGN_IN_SUCCESS':
+            return { user: payload.user, isSignIn: true };
+        case 'SIGN_IN_ERROR':
+        case 'SIGN_OUT':
+            return { isSignIn: false };
+        case 'CHANGE_NICKNAME':
+            return { ...userInfo, user: payload.user };
+        default:
+            return '';
+    }
+}

--- a/frontend/src/reducer/userAuthReducer.js
+++ b/frontend/src/reducer/userAuthReducer.js
@@ -8,6 +8,6 @@ export default function userAuthReducer(userInfo, { type, payload }) {
         case 'CHANGE_NICKNAME':
             return { ...userInfo, user: payload.user };
         default:
-            return '';
+            return {};
     }
 }


### PR DESCRIPTION
## 관련 이슈
#243 

## 작업 설명
- [X]  Header.jsx
    - 코드가 150줄이며, View를 제외한 로직이 너무 많음
    - 상수로 뺼 수 있는 겉은 빼보고 실패 처리, 성공 처리에 대한 상태 로직은 별도로 분리해야 함
 - [X]  **useAuth의 useInfo는 로그인, 로그아웃, 닉네임 변경 3가지의 기능이 사용 됨.**
    - **이러면 상태 로직을 View의 prop으로 내려주거나 reducer를 사용하는 방식으로 개선해야 함.**
    - **하지만, 3가지의 기능을 적용하기 위해서는 자식 컴포넌트에서 굳이 상태 변경 관련 로직을 적을 필요가 없음. `dispatch` 를 통해 reducer에서 상태 관리를 담당하도록 변경 해야 함.**

